### PR TITLE
Remove selectors in `declare-term-types`

### DIFF
--- a/non-deterministic/ring-mod.sl
+++ b/non-deterministic/ring-mod.sl
@@ -23,9 +23,9 @@
    ($fx)
    ($0)
    ($1)
-   ($+ ($+_1 Start) ($+_2 Start))
-   ($- ($-_1 Start) ($-_2 Start))
-   ($mux ($mux_1 Start) ($mux_2 Start)))))
+   ($+ Start Start)
+   ($- Start Start)
+   ($mux Start Start))))
 
 ;;;
 ;;; Semantics


### PR DESCRIPTION
Updating the ring mod benchmark to remove selectors in `declare-term-types`.