### PR TITLE
Remove selectors in manually-constructed regex benchmarks

### DIFF
--- a/regular-expressions/manually-constructed/regex2-byhand.sl
+++ b/regular-expressions/manually-constructed/regex2-byhand.sl
@@ -10,7 +10,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -18,9 +18,9 @@
             ($char_1)
             ($char_2)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex3-byhand.sl
+++ b/regular-expressions/manually-constructed/regex3-byhand.sl
@@ -10,7 +10,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -18,9 +18,9 @@
             ($char_1)
             ($char_2)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex4-either-pair.sl
+++ b/regular-expressions/manually-constructed/regex4-either-pair.sl
@@ -4,7 +4,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -14,9 +14,9 @@
             ($char_3)
             ($char_4)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex4-simple.sl
+++ b/regular-expressions/manually-constructed/regex4-simple.sl
@@ -4,7 +4,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -14,9 +14,9 @@
             ($char_3)
             ($char_4)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex4.sl
+++ b/regular-expressions/manually-constructed/regex4.sl
@@ -4,7 +4,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -12,9 +12,9 @@
             ($char_1)
             ($char_2)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex4a.sl
+++ b/regular-expressions/manually-constructed/regex4a.sl
@@ -4,7 +4,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -14,9 +14,9 @@
             ($char_3)
             ($char_4)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex5-aa.sl
+++ b/regular-expressions/manually-constructed/regex5-aa.sl
@@ -4,7 +4,7 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
@@ -12,9 +12,9 @@
             ($char_1)
             ($char_2)
             ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ;; ($star ($star_1 R))
+            ($or R R)
+            ($concat R R)
+            ;; ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex6.sl
+++ b/regular-expressions/manually-constructed/regex6.sl
@@ -4,18 +4,18 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
             ($phi)
             ($char_1)
-                ($char_2)
-                ($char_3)
-                ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($char_2)
+            ($char_3)
+            ($any)
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )

--- a/regular-expressions/manually-constructed/regex8-aa.sl
+++ b/regular-expressions/manually-constructed/regex8-aa.sl
@@ -4,23 +4,23 @@
     
     ;; Productions
     (
-        (($eval($eval_1 R)))
+        (($eval R))
     
         (
             ($eps)
             ($phi)
             ($char_1)
-                ($char_2)
-                ($char_3)
-                ($char_4)
-                ($char_5)
-                ($char_6)
-                ($char_7)
-                ($char_8)
-                ($any)
-            ($or ($or_1 R) ($or_2 R))
-            ($concat ($concat_1 R) ($concat_2 R))
-            ($star ($star_1 R))
+            ($char_2)
+            ($char_3)
+            ($char_4)
+            ($char_5)
+            ($char_6)
+            ($char_7)
+            ($char_8)
+            ($any)
+            ($or R R)
+            ($concat R R)
+            ($star R)
         )
     )
 )
@@ -243,8 +243,7 @@
     )
 )
 
-(synth-fun match_regex() Start
-(
+(synth-fun match_regex () Start
     ((nt_Start Start) (nt_R R) (nt_Good R) (nt_Bad R) (t_a R) (t_b R) (t_Kludge R))
     (
         (nt_Start Start (($eval nt_R)))
@@ -255,9 +254,8 @@
         (t_b R ($char_2))
         (t_Kludge R ($phi))
     )
+)
 
-)
-)
 
 (constraint (Start.Sem match_regex 1 1 1 1 1 1 1 1 true))
 (constraint (Start.Sem match_regex 1 1 1 1 2 1 1 1 false))


### PR DESCRIPTION
Closes #12. We remove selectors from `declare-term-types` declarations.