### PR TITLE
fix: missing assignment for retval in bv benchmark

### DIFF
--- a/messy/basic_bv/BVtest_ADD_01.sem
+++ b/messy/basic_bv/BVtest_ADD_01.sem
@@ -23,7 +23,7 @@
 ($IBVVarx (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)
   (= r__1 x))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_AND_01.sem
+++ b/messy/basic_bv/BVtest_AND_01.sem
@@ -19,7 +19,7 @@
 ($IBVVary (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)
   (= r__1 y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_AND_02.sem
+++ b/messy/basic_bv/BVtest_AND_02.sem
@@ -19,7 +19,7 @@
 ($IBVVary (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)
   (= r__1 y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_AND_03.sem
+++ b/messy/basic_bv/BVtest_AND_03.sem
@@ -22,7 +22,7 @@
   (E.Sem E_term_1 r__1 x y)
   (E.Sem E_term_2 r__2 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_MAX_01.sem
+++ b/messy/basic_bv/BVtest_MAX_01.sem
@@ -27,7 +27,7 @@
   (E.Sem E_term_1 r__1 x y)
   (E.Sem E_term_2 r__2 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_NAND_01.sem
+++ b/messy/basic_bv/BVtest_NAND_01.sem
@@ -22,7 +22,7 @@
 (($bvneg E_term_1) (exists ((r__1 (_ BitVec 32))) (and (= r__0 (bvnot r__1))
   (E.Sem E_term_1 r__1 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_PLUS_01.sem
+++ b/messy/basic_bv/BVtest_PLUS_01.sem
@@ -19,7 +19,7 @@
 ($IBVVary (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)
   (= r__1 y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_Swap_XOR_01.sem
+++ b/messy/basic_bv/BVtest_Swap_XOR_01.sem
@@ -22,11 +22,11 @@
   ((($seq Start1_term_1 Start1_term_2) (exists ((x_r1 (_ BitVec 32)) (y_r1 (_ BitVec 32))) (and (Start1.Sem Start1_term_1 x_r1 y_r1 x y)
   (Start1.Sem Start1_term_2 x_r0 y_r0 x_r1 y_r1))))))
 (match Start1_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))
 (($bv=y E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x x_r0)
-  (= y r__1))
+  (= y_r0 r__1))
   (E.Sem E_term_1 r__1 x y))))))
 (match V_term_0
   (($IBVVary (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)

--- a/messy/basic_bv/BVtest_Swap_XOR_02.sem
+++ b/messy/basic_bv/BVtest_Swap_XOR_02.sem
@@ -22,11 +22,11 @@
   ((($seq Start1_term_1 Start1_term_2) (exists ((x_r1 (_ BitVec 32)) (y_r1 (_ BitVec 32))) (and (Start1.Sem Start1_term_1 x_r1 y_r1 x y)
   (Start1.Sem Start1_term_2 x_r0 y_r0 x_r1 y_r1))))))
 (match Start1_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))
 (($bv=y E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x x_r0)
-  (= y r__1))
+  (= y_r0 r__1))
   (E.Sem E_term_1 r__1 x y))))))
 (match V_term_0
   (($IBVVary (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)

--- a/messy/basic_bv/BVtest_Swap_XOR_03.sem
+++ b/messy/basic_bv/BVtest_Swap_XOR_03.sem
@@ -23,11 +23,11 @@
 (match Start_term_0
   ((($seq Start_term_1 Start_term_2) (exists ((x_r1 (_ BitVec 32)) (y_r1 (_ BitVec 32))) (and (Start.Sem Start_term_1 x_r1 y_r1 x y)
   (Start.Sem Start_term_2 x_r0 y_r0 x_r1 y_r1))))
-(($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+(($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))
 (($bv=y E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x x_r0)
-  (= y r__1))
+  (= y_r0 r__1))
   (E.Sem E_term_1 r__1 x y))))))))
 
 

--- a/messy/basic_bv/BVtest_While_01_XOR_by_AND_OR.sem
+++ b/messy/basic_bv/BVtest_While_01_XOR_by_AND_OR.sem
@@ -36,7 +36,7 @@
   ((($bv=y E1_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x x_r0)
   (= y r__1))
   (E1.Sem E1_term_1 r__1 x y))))
-(($bv=x E1_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+(($bv=x E1_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E1.Sem E1_term_1 r__1 x y))))
 (($seq S_term_1 S_term_2) (exists ((x_r1 (_ BitVec 32)) (y_r1 (_ BitVec 32))) (and (S.Sem S_term_1 x_r1 y_r1 x y)

--- a/messy/basic_bv/BVtest_While_02_XOR_by_AND_OR_ADD.sem
+++ b/messy/basic_bv/BVtest_While_02_XOR_by_AND_OR_ADD.sem
@@ -36,7 +36,7 @@
 ($IBVVarx (exists ((r__1 (_ BitVec 32))) (and (= r__0 r__1)
   (= r__1 x))))))
 (match S_term_0
-  ((($bv=x E1_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E1_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E1.Sem E1_term_1 r__1 x y))))
 (($seq S_term_1 S_term_2) (exists ((x_r1 (_ BitVec 32)) (y_r1 (_ BitVec 32))) (and (S.Sem S_term_1 x_r1 y_r1 x y)

--- a/messy/basic_bv/BVtest_XOR_01.sem
+++ b/messy/basic_bv/BVtest_XOR_01.sem
@@ -23,7 +23,7 @@
   (E.Sem E_term_1 r__1 x y)
   (E.Sem E_term_2 r__2 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_XOR_02.sem
+++ b/messy/basic_bv/BVtest_XOR_02.sem
@@ -26,7 +26,7 @@
   (E.Sem E_term_1 r__1 x y)
   (E.Sem E_term_2 r__2 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 

--- a/messy/basic_bv/BVtest_XOR_03.sem
+++ b/messy/basic_bv/BVtest_XOR_03.sem
@@ -27,7 +27,7 @@
   (E.Sem E_term_1 r__1 x y)
   (E.Sem E_term_2 r__2 x y))))))
 (match Start_term_0
-  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x r__1)
+  ((($bv=x E_term_1) (exists ((r__1 (_ BitVec 32))) (and (and (= x_r0 r__1)
   (= y y_r0))
   (E.Sem E_term_1 r__1 x y))))))))
 


### PR DESCRIPTION
Some semantics relations in bitvector benchmarks are wrong, because output states `x_r0` and `y_r0` are not properly assigned. This commit fixes those mistakes.

ref: https://madpl.slack.com/archives/C043H99TFNK/p1675044136106829